### PR TITLE
add a type definition file for typescript users

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,4 @@
+declare module 'unhomoglyph' {
+    const unhomoglyph: (s: string) => string;
+    export default unhomoglyph;
+}


### PR DESCRIPTION
### Summary
This allows type-checking when importing from typescript projects.

### Testing
Tested against my imports of `unhomoglyph` from [matrix-org/matrix-js-sdk](https://github.com/matrix-org/matrix-js-sdk/).

I've converted a file which imports `unhomoglyph` to typescript.

I modified the import as so:
```
-import * as unhomoglyph from 'unhomoglyph';
+import unhomoglyph from 'unhomoglyph';
```

And ensured we were in strict mode in `tsconfig.json`:
```
-    "noImplicitAny": false,
+    "noImplicitAny": true,
```

* I ran `yarn build` in my directory and got a type error for `unhomoglyph`
* I switched to this branch locally and ran `yarn link`
* I switched to my project and ran `yarn link unhomoglyph`
* I ran `yarn install --force`
* I re-ran `yarn build` and the type error had disappeared.

I also ensured the types are used properly by breaking them in my project and checking that the build fails:
```
src/utils.ts:658:5 - error TS2322: Type 'string' is not assignable to type 'number'.
658     return unhomoglyph(str.normalize('NFD').replace(removeHiddenCharsRegex, ''));
```

```
src/utils.ts:658:24 - error TS2345: Argument of type '4' is not assignable to parameter of type 'string'.
658     return unhomoglyph(4);
```


